### PR TITLE
Fix inconsistent usage of "recursively" option for visibility flags

### DIFF
--- a/addons/GME/Scripts/Game/GME/Helpers/GME_VisibilityHelper.c
+++ b/addons/GME/Scripts/Game/GME/Helpers/GME_VisibilityHelper.c
@@ -24,7 +24,6 @@ class GME_VisibilityHelper
 	
 	static bool GetVisibility(IEntity entity)
 	{
-		int visible = entity.GetFlags() & EntityFlags.VISIBLE;
-		return visible;
+		return entity.GetFlags() & EntityFlags.VISIBLE;
 	}
 }

--- a/addons/GME/Scripts/Game/GME/Helpers/GME_VisibilityHelper.c
+++ b/addons/GME/Scripts/Game/GME/Helpers/GME_VisibilityHelper.c
@@ -1,9 +1,8 @@
-/**
-Helper class with staic functions to enable and disable visiblity of units
-*/
-
+//------------------------------------------------------------------------------------------------
+//! Helper class with staic functions to enable and disable visiblity of units
 class GME_VisibilityHelper
 {
+	//------------------------------------------------------------------------------------------------
 	static void SetVisibility(GenericEntity entity, bool visible)
 	{
 		// casting to possible supported types, if not null we found our match and change visibility and return
@@ -22,6 +21,7 @@ class GME_VisibilityHelper
 		}
 	}
 	
+	//------------------------------------------------------------------------------------------------
 	static bool GetVisibility(IEntity entity)
 	{
 		return entity.GetFlags() & EntityFlags.VISIBLE;

--- a/addons/GME/Scripts/GameCode/GME/Character/SCR_ChimeraCharacter.c
+++ b/addons/GME/Scripts/GameCode/GME/Character/SCR_ChimeraCharacter.c
@@ -42,6 +42,6 @@ modded class SCR_ChimeraCharacter : ChimeraCharacter
 	{		
 		m_bGME_isVisible = visible;
 		Replication.BumpMe();
-		this.GME_OnVisibilityValueUpdated();
+		GME_OnVisibilityValueUpdated();
 	}
 }

--- a/addons/GME/Scripts/GameCode/GME/Character/SCR_ChimeraCharacter.c
+++ b/addons/GME/Scripts/GameCode/GME/Character/SCR_ChimeraCharacter.c
@@ -32,9 +32,9 @@ modded class SCR_ChimeraCharacter : ChimeraCharacter
 	void GME_OnVisibilityValueUpdated()
 	{
 		if (m_bGME_isVisible)
-			this.SetFlags(EntityFlags.VISIBLE|EntityFlags.TRACEABLE, m_bGME_isVisible);
+			SetFlags(EntityFlags.VISIBLE | EntityFlags.TRACEABLE);
 		else
-			this.ClearFlags(EntityFlags.VISIBLE|EntityFlags.TRACEABLE);
+			ClearFlags(EntityFlags.VISIBLE | EntityFlags.TRACEABLE);
 	}
 	
 	//------------------------------------------------------------------------------------------------

--- a/addons/GME/Scripts/GameCode/GME/Character/SCR_ChimeraCharacter.c
+++ b/addons/GME/Scripts/GameCode/GME/Character/SCR_ChimeraCharacter.c
@@ -29,19 +29,19 @@ modded class SCR_ChimeraCharacter : ChimeraCharacter
 	}
 	
 	//------------------------------------------------------------------------------------------------
-	void GME_OnVisibilityValueUpdated()
+	void GME_SetVisibility(bool visible)
+	{
+		m_bGME_isVisible = visible;
+		Replication.BumpMe();
+		GME_OnVisibilityValueUpdated();
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	protected void GME_OnVisibilityValueUpdated()
 	{
 		if (m_bGME_isVisible)
 			SetFlags(EntityFlags.VISIBLE | EntityFlags.TRACEABLE);
 		else
 			ClearFlags(EntityFlags.VISIBLE | EntityFlags.TRACEABLE);
-	}
-	
-	//------------------------------------------------------------------------------------------------
-	void GME_SetVisibility(bool visible)
-	{		
-		m_bGME_isVisible = visible;
-		Replication.BumpMe();
-		GME_OnVisibilityValueUpdated();
 	}
 }

--- a/addons/GME/Scripts/GameCode/GME/Vehicle/Vehicle.c
+++ b/addons/GME/Scripts/GameCode/GME/Vehicle/Vehicle.c
@@ -17,8 +17,8 @@ modded class Vehicle : BaseVehicle
 	void GME_OnVisibilityValueUpdated()
 	{
 		if (m_bGME_isVisible)
-			this.SetFlags(EntityFlags.VISIBLE|EntityFlags.TRACEABLE, m_bGME_isVisible);
+			SetFlags(EntityFlags.VISIBLE | EntityFlags.TRACEABLE);
 		else
-			this.ClearFlags(EntityFlags.VISIBLE|EntityFlags.TRACEABLE);
+			ClearFlags(EntityFlags.VISIBLE | EntityFlags.TRACEABLE);
 	}
 };

--- a/addons/GME/Scripts/GameCode/GME/Vehicle/Vehicle.c
+++ b/addons/GME/Scripts/GameCode/GME/Vehicle/Vehicle.c
@@ -1,20 +1,19 @@
-
-
 //------------------------------------------------------------------------------------------------
 modded class Vehicle : BaseVehicle
 {
 	[RplProp(onRplName: "GME_OnVisibilityValueUpdated")]
 	protected bool m_bGME_isVisible = true;
 	
+	//------------------------------------------------------------------------------------------------
 	void GME_SetVisibility(bool visible)
-	{		
+	{
 		m_bGME_isVisible = visible;
 		Replication.BumpMe();
 		GME_OnVisibilityValueUpdated();
 	}
 	
-	
-	void GME_OnVisibilityValueUpdated()
+	//------------------------------------------------------------------------------------------------
+	protected void GME_OnVisibilityValueUpdated()
 	{
 		if (m_bGME_isVisible)
 			SetFlags(EntityFlags.VISIBLE | EntityFlags.TRACEABLE);

--- a/addons/GME/Scripts/GameCode/GME/Vehicle/Vehicle.c
+++ b/addons/GME/Scripts/GameCode/GME/Vehicle/Vehicle.c
@@ -10,7 +10,7 @@ modded class Vehicle : BaseVehicle
 	{		
 		m_bGME_isVisible = visible;
 		Replication.BumpMe();
-		this.GME_OnVisibilityValueUpdated();
+		GME_OnVisibilityValueUpdated();
 	}
 	
 	


### PR DESCRIPTION
**When merged this pull request will:**
- Remove recursive application of `SetFlags`
- Remove unnecessary `this`
- Apply proper format for comments

**Background:**
- Second argument of `SetFlags` and `ClearFlags` is whether it is applied recursively, which was inconsistently set.