### PR TITLE
Fix typo in intel title

### DIFF
--- a/addons/GME/Language/GME_localization.cs_cz.conf
+++ b/addons/GME/Language/GME_localization.cs_cz.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.en_us.conf
+++ b/addons/GME/Language/GME_localization.en_us.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.es_es.conf
+++ b/addons/GME/Language/GME_localization.es_es.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.fr_fr.conf
+++ b/addons/GME/Language/GME_localization.fr_fr.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.it_it.conf
+++ b/addons/GME/Language/GME_localization.it_it.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.ja_jp.conf
+++ b/addons/GME/Language/GME_localization.ja_jp.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.ko_kr.conf
+++ b/addons/GME/Language/GME_localization.ko_kr.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.pl_pl.conf
+++ b/addons/GME/Language/GME_localization.pl_pl.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.pt_br.conf
+++ b/addons/GME/Language/GME_localization.pt_br.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.ru_ru.conf
+++ b/addons/GME/Language/GME_localization.ru_ru.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.st
+++ b/addons/GME/Language/GME_localization.st
@@ -396,11 +396,11 @@ StringTable {
   }
   CustomStringTableItem "{62A6ECE003544E7E}" {
    Id "GME-Editor_Attribute_IntelTitel_Name"
-   Target_en_us "Intel titel"
+   Target_en_us "Intel title"
    Target_de_de "Hinweistitel"
-   Modified 1655109662
+   Modified 1656551081
    Author "Kexanone"
-   LastChanged "Kexanone"
+   LastChanged "crow"
   }
   CustomStringTableItem "{62AB6754F6815523}" {
    Id "GME-Editor_Attribute_Skill_CYLON_Name"

--- a/addons/GME/Language/GME_localization.uk_ua.conf
+++ b/addons/GME/Language/GME_localization.uk_ua.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"

--- a/addons/GME/Language/GME_localization.zh_cn.conf
+++ b/addons/GME/Language/GME_localization.zh_cn.conf
@@ -74,7 +74,7 @@ StringTableRuntime {
   "Global skill applied to all current and future AI units."
   "Global skill"
   "Intel content"
-  "Intel titel"
+  "Intel title"
   "Cylon"
   "Skill of the AI"
   "Expert"


### PR DESCRIPTION
Fixes typo in "intel title"
