### PR TITLE
Use base game invoker for delayed member spawning

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -10,3 +10,4 @@ Crowdedlight <crowdedhd@gmail.com>
 Kexanone <kexanone@gmail.com>
 
 # CONTRIBUTORS
+Domagoj K. Hackenberger <domagojhack@gmail.com>

--- a/addons/GME/Scripts/Game/GME/Entities/SCR_AIGroup.c
+++ b/addons/GME/Scripts/Game/GME/Entities/SCR_AIGroup.c
@@ -2,32 +2,29 @@
 modded class SCR_AIGroup : ChimeraAIGroup
 {
 	protected bool m_bGME_IsMemberSpawningDone = false;
-	protected ref ScriptInvoker m_GME_OnDoneSpawningMembers;
 	
 	//------------------------------------------------------------------------------------------------
 	override void EOnInit(IEntity owner)
 	{
 		super.EOnInit(owner);
 
+		// Inserted before any consumer, so that GME_IsMemberSpawningDone() is already up to date
+		// once their handlers are invoked
 		GetOnAllDelayedEntitySpawned().Insert(GME_OnAllDelayedEntitySpawned);
 	}
 
 	//------------------------------------------------------------------------------------------------
 	protected void GME_OnAllDelayedEntitySpawned(SCR_AIGroup group)
 	{
-		if (m_GME_OnDoneSpawningMembers)
-			m_GME_OnDoneSpawningMembers.Invoke(this);
-
 		m_bGME_IsMemberSpawningDone = true;
 	}
 	
 	//------------------------------------------------------------------------------------------------
-	ScriptInvoker GME_GetOnDoneSpawningMembers()
+	//! Event invoked once all delayed group members have spawned.
+	//! Provided by the base game since Reforger 1.8.0, GME only tracks its completion state.
+	ScriptInvokerBase<ScriptInvokerAIGroup> GME_GetOnDoneSpawningMembers()
 	{
-		if (!m_GME_OnDoneSpawningMembers)
-			m_GME_OnDoneSpawningMembers = new ScriptInvoker();
-		
-		return m_GME_OnDoneSpawningMembers;
+		return GetOnAllDelayedEntitySpawned();
 	}
 	
 	//------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**When merged this pull request will:**
- Drop GME's own `m_GME_OnDoneSpawningMembers` invoker and have `GME_GetOnDoneSpawningMembers()` return the base game's `SCR_AIGroup.GetOnAllDelayedEntitySpawned()` directly, now that #80 hooks that event
- Keep `GME_GetOnDoneSpawningMembers()` and `GME_IsMemberSpawningDone()` as wrappers, so the add garrison, spawn reinforcements and ambient flyby modules stay unchanged

The persistence serializer changes that were originally part of this PR have been dropped in favour of #83.
