### PR TITLE
Fix binary persistence serialization

### DIFF
--- a/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/GME_HitZoneContainerComponentSerializer.c
+++ b/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/GME_HitZoneContainerComponentSerializer.c
@@ -4,25 +4,45 @@ class GME_HitZoneContainerComponentSerializer : HitZoneContainerComponentSeriali
 	//------------------------------------------------------------------------------------------------
 	override protected ESerializeResult Serialize(notnull IEntity owner, notnull GenericComponent component, notnull SaveContext context)
 	{
-		ESerializeResult result = super.Serialize(owner, component, context);
-		if (result == ESerializeResult.ERROR)
-			return result;
+		const SCR_DamageManagerComponent damageManager = SCR_DamageManagerComponent.Cast(component);
 		
-		SCR_DamageManagerComponent damageManager = SCR_DamageManagerComponent.Cast(component);
-		if (!damageManager.IsDamageHandlingEnabled())
+        context.StartObject("base");
+		const ESerializeResult baseResult = super.Serialize(owner, component, context);
+        context.EndObject();
+		
+		if (baseResult == ESerializeResult.ERROR)
+			return ESerializeResult.ERROR;
+		
+		const bool damageHandlingEnabled = damageManager.IsDamageHandlingEnabled();
+		
+		if (baseResult == ESerializeResult.DEFAULT &&
+			damageHandlingEnabled)
 		{
-			context.WriteValue("damageHandlingEnabled", false);
-			result = ESerializeResult.OK;
+			return ESerializeResult.DEFAULT;
 		}
 		
-		return result;
+		context.WriteValue("version", 1);
+		context.WriteDefault(damageHandlingEnabled, true);
+		return ESerializeResult.OK;
 	}
 	
 	//------------------------------------------------------------------------------------------------
 	override protected bool Deserialize(notnull IEntity owner, notnull GenericComponent component, notnull LoadContext context)
 	{
-		super.Deserialize(owner, component, context);
 		SCR_DamageManagerComponent damageManager = SCR_DamageManagerComponent.Cast(component);
+
+		if (context.DoesObjectExist("base"))
+		{
+			if (!context.StartObject("base") ||
+				!super.Deserialize(owner, component, context) ||
+				!context.EndObject())
+			{
+				return false;
+			}
+		}
+		
+		int version;
+		context.Read(version);
 		
 		bool damageHandlingEnabled;
 		if (context.Read(damageHandlingEnabled))

--- a/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/GME_IntelComponentSerializer.c
+++ b/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/GME_IntelComponentSerializer.c
@@ -10,14 +10,16 @@ class GME_IntelComponentSerializer : ScriptedComponentSerializer
 	//------------------------------------------------------------------------------------------------
 	override protected ESerializeResult Serialize(notnull IEntity owner, notnull GenericComponent component, notnull SaveContext context)
 	{
-
-		GME_IntelComponent intel = GME_IntelComponent.Cast(component);
+		const GME_IntelComponent intel = GME_IntelComponent.Cast(component);
 		if (!intel.HasIntel())
 			return ESerializeResult.DEFAULT;
 		
+		const string title = intel.GetTitle();
+		const string content = intel.GetContent();
+		
 		context.WriteValue("version", 1);
-		context.WriteValue("title", intel.GetTitle());
-		context.WriteValue("content", intel.GetContent());
+		context.Write(title);
+		context.Write(content);
 		return ESerializeResult.OK;
 	}
 	
@@ -25,14 +27,18 @@ class GME_IntelComponentSerializer : ScriptedComponentSerializer
 	override protected bool Deserialize(notnull IEntity owner, notnull GenericComponent component, notnull LoadContext context)
 	{
 		GME_IntelComponent intel = GME_IntelComponent.Cast(component);
+		
 		int version;
 		context.Read(version);
+		
 		string title;
 		context.Read(title);
 		intel.SetTitle(title);
+		
 		string content;
 		context.Read(content);
 		intel.SetContent(content);
+		
 		return true;
 	}
 }

--- a/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/GME_Modules_EditablePointComponentSerializer.c
+++ b/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/GME_Modules_EditablePointComponentSerializer.c
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------------------------
-class GME_Modules_EditablePointComponentSerializer : ScriptedComponentSerializer
+class GME_Modules_EditablePointComponentSerializer : SCR_EditableEntityComponentSerializer
 {
 	//------------------------------------------------------------------------------------------------
 	override static typename GetTargetType()
@@ -10,10 +10,19 @@ class GME_Modules_EditablePointComponentSerializer : ScriptedComponentSerializer
 	//------------------------------------------------------------------------------------------------
 	override protected ESerializeResult Serialize(notnull IEntity owner, notnull GenericComponent component, notnull SaveContext context)
 	{
-
-		GME_Modules_EditablePointComponent point = GME_Modules_EditablePointComponent.Cast(component);
+		const GME_Modules_EditablePointComponent point = GME_Modules_EditablePointComponent.Cast(component);
+		
+        context.StartObject("base");
+		const ESerializeResult baseResult = super.Serialize(owner, component, context);
+        context.EndObject();
+		
+		if (baseResult == ESerializeResult.ERROR)
+			return ESerializeResult.ERROR;
+		
+		const LocalizedString callsign = point.GetCallsign();
+		
 		context.WriteValue("version", 1);
-		context.WriteValue("callsign", point.GetCallsign());
+		context.Write(callsign);
 		return ESerializeResult.OK;
 	}
 	
@@ -21,11 +30,24 @@ class GME_Modules_EditablePointComponentSerializer : ScriptedComponentSerializer
 	override protected bool Deserialize(notnull IEntity owner, notnull GenericComponent component, notnull LoadContext context)
 	{
 		GME_Modules_EditablePointComponent point = GME_Modules_EditablePointComponent.Cast(component);
+		
+		if (context.DoesObjectExist("base"))
+		{
+			if (!context.StartObject("base") ||
+				!super.Deserialize(owner, component, context) ||
+				!context.EndObject())
+			{
+				return false;
+			}
+		}
+		
 		int version;
 		context.Read(version);
+		
 		string callsign;
-		context.Read(callsign);
-		point.SetCallsign(callsign);
+		if (context.Read(callsign))
+			point.SetCallsign(callsign);
+		
 		return true;
 	}
 }

--- a/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/GME_WaypointEntitySerializer.c
+++ b/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/GME_WaypointEntitySerializer.c
@@ -10,41 +10,57 @@ class GME_WaypointEntitySerializer : GenericEntitySerializer
 	//------------------------------------------------------------------------------------------------
 	override protected ESerializeResult Serialize(notnull IEntity entity, notnull SaveContext context)
 	{
-		ESerializeResult result = super.Serialize(entity, context);
-		if (result == ESerializeResult.ERROR)
-			return result;
+		const AIWaypoint waypoint = AIWaypoint.Cast(entity);
 		
-		AIWaypoint waypoint = AIWaypoint.Cast(entity);
+        context.StartObject("base");
+        const ESerializeResult baseResult = super.Serialize(entity, context);
+        context.EndObject();
 		
+		if (baseResult == ESerializeResult.ERROR)
+			return ESerializeResult.ERROR;
+				
 		BaseContainer container = waypoint.GetPrefabData().GetPrefab();
 		if (!container)
 			return ESerializeResult.ERROR;
 		
-		float defaultRadius;
-		container.Get("CompletionRadius", defaultRadius);
-		EAIWaypointCompletionType defaultType;
-		container.Get("CompletionType", defaultType);
+		const float completionRadius = waypoint.GetCompletionRadius();
+		const EAIWaypointCompletionType completionType = waypoint.GetCompletionType();
 		
-		if (defaultRadius != waypoint.GetCompletionRadius())
+		float defaultCompletionRadius;
+		container.Get("CompletionRadius", defaultCompletionRadius);
+		EAIWaypointCompletionType defaultCompletionType;
+		container.Get("CompletionType", defaultCompletionType);
+		
+		if (baseResult == ESerializeResult.DEFAULT &&
+			defaultCompletionRadius == completionRadius &&
+			defaultCompletionType == completionType)
 		{
-			context.WriteValue("completionRadius", waypoint.GetCompletionRadius());
-			result = ESerializeResult.OK;
+			return ESerializeResult.DEFAULT;
 		}
 		
-		if (defaultType != waypoint.GetCompletionType())
-		{
-			context.WriteValue("completionType", waypoint.GetCompletionType());
-			result = ESerializeResult.OK;
-		}
-		
-		return result;
+		context.WriteValue("version", 1);
+		context.WriteDefault(completionRadius, defaultCompletionRadius);
+		context.WriteDefault(completionType, defaultCompletionType);
+		return ESerializeResult.OK;
 	}
 	
 	//------------------------------------------------------------------------------------------------
 	override protected bool Deserialize(notnull IEntity entity, notnull LoadContext context)
 	{
-		super.Deserialize(entity, context);
 		AIWaypoint waypoint = AIWaypoint.Cast(entity);
+		
+		if (context.DoesObjectExist("base"))
+		{
+			if (!context.StartObject("base") ||
+				!super.Deserialize(entity, context) ||
+				!context.EndObject())
+			{
+				return false;
+			}
+		}
+		
+		int version;
+		context.Read(version);
 		
 		float completionRadius;
 		if (context.Read(completionRadius))

--- a/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/SCR_EditableEntityComponentSerializer.c
+++ b/addons/GME/Scripts/Game/GME/Systems/Persistence/Serializers/SCR_EditableEntityComponentSerializer.c
@@ -4,25 +4,45 @@ modded class SCR_EditableEntityComponentSerializer : ScriptedComponentSerializer
 	//------------------------------------------------------------------------------------------------
 	override protected ESerializeResult Serialize(notnull IEntity owner, notnull GenericComponent component, notnull SaveContext context)
 	{
-		ESerializeResult result = super.Serialize(owner, component, context);
-		if (result == ESerializeResult.ERROR)
-			return result;
+		const SCR_EditableEntityComponent editable = SCR_EditableEntityComponent.Cast(component);
+
+        context.StartObject("base");
+		const ESerializeResult baseResult = super.Serialize(owner, component, context);
+        context.EndObject();
 		
-		SCR_EditableEntityComponent editable = SCR_EditableEntityComponent.Cast(component);
-		if (!editable.GME_IsVisible())
+		if (baseResult == ESerializeResult.ERROR)
+			return ESerializeResult.ERROR;
+		
+		const bool visible = editable.GME_IsVisible();
+		
+		if (baseResult == ESerializeResult.DEFAULT &&
+			visible)
 		{
-			context.WriteValue("visible", false);
-			result = ESerializeResult.OK;
+			return ESerializeResult.DEFAULT;
 		}
 		
-		return result;
+		context.WriteValue("version", 1);
+		context.WriteDefault(visible, true);
+		return ESerializeResult.OK;
 	}
 	
 	//------------------------------------------------------------------------------------------------
 	override protected bool Deserialize(notnull IEntity owner, notnull GenericComponent component, notnull LoadContext context)
 	{
-		super.Deserialize(owner, component, context);
 		SCR_EditableEntityComponent editable = SCR_EditableEntityComponent.Cast(component);
+		
+		if (context.DoesObjectExist("base"))
+		{
+			if (!context.StartObject("base") ||
+				!super.Deserialize(owner, component, context) ||
+				!context.EndObject())
+			{
+				return false;
+			}
+		}
+		
+		int version;
+		context.Read(version);
 		
 		bool visible;
 		if (context.Read(visible))


### PR DESCRIPTION
**When merged this pull request will:**
- Switch to recommended binary-compatible pattern of writing `Serialize` and `Deserialize` methods
- Resolves #78 

**Background:**
- Since a version of 1.7, binary serialization was introduced as default for persistence. Unlike JSON serialization, data is stored positional instead of key-value pairs.
- A primary issue with the positional approach is the handling of calling `super.Deserialize`, as they will read in garbage if `super.Serialize` wrote nothing and returned `ESerializeResult.DEFAULT`. The solution to this is to wrap the base serialization into a separate `base` object, as seen in the implementation of `SCR_ScenarioFrameworkTriggerEntitySerializer`, for instance.